### PR TITLE
Md5 fingerprint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # RETS Changelog
 
+## 0.1.2
+* getObject dictionaries now include md5 fingerprints as content_md5
+
+## 0.1.1
+* Multipart image downloads working in Python2. Still not working in Python3
+
 ## 0.1.0
 * No results continues generator
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,4 +23,3 @@
 
 ## 0.0.7
 * Streaming search results
-

--- a/rets/__init__.py
+++ b/rets/__init__.py
@@ -1,7 +1,7 @@
 from .session import Session
 
 __title__ = 'rets'
-__version__ = '0.1.1'
+__version__ = '0.1.2'
 __author__ = 'REfindly'
 __license__ = 'MIT'
 __copyright__ = 'Copyright 2016 REfindly'

--- a/rets/parsers/get_object.py
+++ b/rets/parsers/get_object.py
@@ -2,6 +2,7 @@ import xmltodict
 from rets.exceptions import ParseError
 from rets.parsers.base import Base
 import sys
+import hashlib
 
 PY2 = sys.version_info[0] == 2
 
@@ -58,6 +59,11 @@ class MultipleObjectParser(Base):
             part_header_dict = {k.strip(): v.strip() for k, v in (h.split(':') for h in header.split('\r\n'))}
             obj = dict()
             obj['content'] = body if PY2 else body.encode(response.encoding)
+
+            md = hashlib.md5()
+            md.update(obj['content'])
+            obj['content_md5'] = md.hexdigest()
+
             obj['content_description'] = part_header_dict.get('Content-Description',
                                                               response.headers.get('Content-Description'))
             obj['content_sub_description'] = part_header_dict.get('Content-Sub-Description',
@@ -74,6 +80,7 @@ class MultipleObjectParser(Base):
                                                        response.headers.get('MIME-Version'))
             obj['preferred'] = part_header_dict.get('Preferred',
                                                     response.headers.get('Preferred'))
+
 
             parsed.append(obj)
 
@@ -95,6 +102,11 @@ class SingleObjectParser(Base):
 
         obj = dict()
         obj['content'] = response.content
+
+        md = hashlib.md5()
+        md.update(obj['content'])
+        obj['content_md5'] = md.hexdigest()
+
         obj['content_description'] = response.headers.get('Content-Description')
         obj['content_sub_description'] = response.headers.get('Content-Sub-Description')
         obj['content_id'] = response.headers.get('Content-ID')

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -72,12 +72,14 @@ class SessionTester(unittest.TestCase):
 
             objs = self.session.get_object(resource='Property', object_type='Photo', content_ids='1', object_ids='1')
             self.assertEqual(len(objs), 1)
+            self.assertEqual(objs[0]['content_md5'], '396106a133a23e10f6926a82d219edbc')
 
             resps.add(resps.POST, 'http://server.rets.com/rets/GetObject.ashx',
                       body=multiple, status=200, adding_headers=multi_headers)
 
             objs1 = self.session.get_object(resource='Property', object_type='Photo', content_ids='1')
             self.assertEqual(len(objs1), 9)
+            self.assertEqual(objs1[0]['content_md5'], '2eb4dc85f124a1c1e5d1e74886332234')
 
     def test_preferred_object(self):
         with open('tests/rets_responses/GetObject_multipart.byte', 'rb') as f:


### PR DESCRIPTION
## Description
Adding md5 checksums to returned images. This should make it easier for users to compare images for duplicates or against their own image storage.

## GitHub Issues
<!-- Proposed changes should be discussed in an issue before submitting a PR. -->
<!-- Link to relevant tickets here. -->
