### PR TITLE
accounts for rets feeds giving characters after XML closing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # RETS Changelog
 
+## 0.3.8
+* Multipart responses with XML and noncomplient rets functions.
+
 ## 0.3.7
 * Addressed potential unicode -> ascii issue in Python2
 

--- a/rets/__init__.py
+++ b/rets/__init__.py
@@ -2,7 +2,7 @@ from .session import Session
 from .exceptions import RETSException
 
 __title__ = 'rets'
-__version__ = '0.3.7'
+__version__ = '0.3.8'
 __author__ = 'REfindly'
 __license__ = 'MIT'
 __copyright__ = 'Copyright 2017 REfindly'

--- a/rets/parsers/get_object.py
+++ b/rets/parsers/get_object.py
@@ -94,6 +94,7 @@ class MultipleObjectParser(ObjectParser):
             # Some multipart requests respond with a text/XML part stating an error
             if 'xml' in part_header_dict.get('Content-Type'):
                 # Got an XML response, likely an error code.
+                body = body[:body.index('/>') + 2]  # Some rets servers give characters after the closing brace.
                 xml = xmltodict.parse(body)
                 try:
                     self.analyze_reply_code(xml_response_dict=xml)

--- a/rets/parsers/get_object.py
+++ b/rets/parsers/get_object.py
@@ -94,7 +94,8 @@ class MultipleObjectParser(ObjectParser):
             # Some multipart requests respond with a text/XML part stating an error
             if 'xml' in part_header_dict.get('Content-Type'):
                 # Got an XML response, likely an error code.
-                body = body[:body.index('/>') + 2]  # Some rets servers give characters after the closing brace.
+                # Some rets servers give characters after the closing brace.
+                body = body[:body.index('>') + 1]  if '/>' in body else body
                 xml = xmltodict.parse(body)
                 try:
                     self.analyze_reply_code(xml_response_dict=xml)

--- a/rets/parsers/get_object.py
+++ b/rets/parsers/get_object.py
@@ -95,7 +95,7 @@ class MultipleObjectParser(ObjectParser):
             if 'xml' in part_header_dict.get('Content-Type'):
                 # Got an XML response, likely an error code.
                 # Some rets servers give characters after the closing brace.
-                body = body[:body.index('/>') + 1]  if '/>' in body else body
+                body = body[:body.index('/>') + 2]  if '/>' in body else body
                 xml = xmltodict.parse(body)
                 try:
                     self.analyze_reply_code(xml_response_dict=xml)

--- a/rets/parsers/get_object.py
+++ b/rets/parsers/get_object.py
@@ -95,7 +95,7 @@ class MultipleObjectParser(ObjectParser):
             if 'xml' in part_header_dict.get('Content-Type'):
                 # Got an XML response, likely an error code.
                 # Some rets servers give characters after the closing brace.
-                body = body[:body.index('>') + 1]  if '/>' in body else body
+                body = body[:body.index('/>') + 1]  if '/>' in body else body
                 xml = xmltodict.parse(body)
                 try:
                     self.analyze_reply_code(xml_response_dict=xml)


### PR DESCRIPTION
## Description
If a rets server gives a multipart response with XML and misc characters, it stops at the close '/>'

## GitHub Issues
<!-- Proposed changes should be discussed in an issue before submitting a PR. -->
<!-- Link to relevant tickets here. -->
