### PR TITLE
Not supplying the default version, letting the server's login respons…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # RETS Changelog
 
+## 0.4.1
+* Not setting the RETS-Version in the header by default anymore. Allowin the login's response to set it.
+
 ## 0.4.0
 * full Python 3 compatibility
 

--- a/README.md
+++ b/README.md
@@ -319,8 +319,10 @@ Many thanks to the passive contribution of [@troydavisson](https://github.com/tr
  make this project successful.
 
 ## Testing
-If you wish to test the code prior to contribution 
-`nosetests --with-coverage --cover-package=rets`
+If you wish to test the code prior to contribution use tox to test on python 2 and 3.
+```bash
+tox
+```
 
 ## Helpful RETS Links
 - http://www.reso.org/glossary/

--- a/rets/__init__.py
+++ b/rets/__init__.py
@@ -2,7 +2,7 @@ from .session import Session
 from .exceptions import RETSException
 
 __title__ = 'rets'
-__version__ = '0.4.0'
+__version__ = '0.4.1'
 __author__ = 'REfindly'
 __license__ = 'MIT'
 __copyright__ = 'Copyright 2017 REfindly'

--- a/rets/session.py
+++ b/rets/session.py
@@ -24,7 +24,7 @@ class Session(object):
 
     allowed_auth = ['basic', 'digest']
 
-    def __init__(self, login_url, username, password=None, version='1.7.2', http_auth='digest',
+    def __init__(self, login_url, username, password=None, version=None, http_auth='digest',
                  user_agent='Python RETS', user_agent_password=None, cache_metadata=True,
                  follow_redirects=True, use_post_method=True, metadata_format='COMPACT-DECODED'):
         """
@@ -64,10 +64,12 @@ class Session(object):
 
         self.client.headers = {
             'User-Agent': self.user_agent,
-            'RETS-Version': '{0!s}'.format(self.version),
             'Accept-Encoding': 'gzip',
             'Accept': '*/*'
         }
+
+        if self.version:
+            self.client.headers['RETS-Version'] = '{0!s}'.format(self.version)
 
         self.follow_redirects = follow_redirects
         self.use_post_method = use_post_method


### PR DESCRIPTION
## Description
When a version is not specified, don't use a default. Allow the server's login response to set the version for the session.

## GitHub Issues
<!-- Proposed changes should be discussed in an issue before submitting a PR. -->
<!-- Link to relevant tickets here. -->
#178