### PR TITLE
Py3 multipart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # RETS Changelog
 
+## 0.4.3
+* Multipart Python3 images bug fixed
+
 ## 0.4.2
 * Removing cached metadata responses if the parsing raises an exception.
 

--- a/rets/__init__.py
+++ b/rets/__init__.py
@@ -2,7 +2,7 @@ from .session import Session
 from .exceptions import RETSException
 
 __title__ = 'rets'
-__version__ = '0.4.2'
+__version__ = '0.4.3'
 __author__ = 'REfindly'
 __license__ = 'MIT'
 __copyright__ = 'Copyright 2017 REfindly'

--- a/rets/parsers/get_object.py
+++ b/rets/parsers/get_object.py
@@ -47,6 +47,7 @@ class MultipleObjectParser(ObjectParser):
         for part in response.headers.get('Content-Type', '').split(';'):
             if 'boundary=' in part:
                 boundary = '--{}'.format(part.split('=', 1)[1].strip('\"'))
+                break
 
         if not boundary:
             raise ParseError("Was not able to find the boundary between objects in a multipart response")
@@ -58,7 +59,7 @@ class MultipleObjectParser(ObjectParser):
 
         if six.PY3:
             # Python3 returns bytes, decode for string operations
-            response_string = response_string.decode()
+            response_string = response_string.decode('latin-1')
 
         #  help bad responses be more multipart compliant
         whole_body = response_string.strip('\r\n')
@@ -112,7 +113,7 @@ class MultipleObjectParser(ObjectParser):
             if body:
                 obj = self._response_object_from_header(
                     obj_head_dict=part_header_dict,
-                    content=body if six.PY2 else body.encode(response.encoding))
+                    content=body.encode('latin-1') if six.PY3 else body)
             else:
                 obj = self._response_object_from_header(obj_head_dict=part_header_dict)
             parsed.append(obj)


### PR DESCRIPTION
## Description
Decoding the py3 bytes into string so we can use the string operations to split apart the multi-part. The encoding given in the response was utf-8 but the decode method doesn't like that, so using latin-1 to decode and then re-encode before continuing.

## GitHub Issues
<!-- Proposed changes should be discussed in an issue before submitting a PR. -->
<!-- Link to relevant tickets here. -->
#182 
