### PR TITLE
Allow non standard cookie names for session id in the Session constructor

### DIFF
--- a/rets/session.py
+++ b/rets/session.py
@@ -26,7 +26,8 @@ class Session(object):
 
     def __init__(self, login_url, username, password=None, version=None, http_auth='digest',
                  user_agent='Python RETS', user_agent_password=None, cache_metadata=True,
-                 follow_redirects=True, use_post_method=True, metadata_format='COMPACT-DECODED'):
+                 follow_redirects=True, use_post_method=True, metadata_format='COMPACT-DECODED',
+                 cookie_name='RETS-Session-ID'):
         """
         Session constructor
         :param login_url: The login URL for the RETS feed
@@ -39,6 +40,7 @@ class Session(object):
         :param use_post_method: Use HTTP POST method when making requests instead of GET. The default is True
         :param metadata_format: COMPACT_DECODED or STANDARD_XML. The client will attempt to set this automatically
         based on response codes from the RETS server.
+        :param cookie_name: The session cookie name returned by the RETS server. Default is RETS-Session-ID
         """
         self.client = requests.Session()
         self.login_url = login_url
@@ -48,6 +50,7 @@ class Session(object):
         self.user_agent_password = user_agent_password
         self.http_authentication = http_auth
         self.cache_metadata = cache_metadata
+        self.cookie_name = cookie_name
         self.capabilities = {}
         self.version = version  # Set by the RETS server response at login. You can override on initialization.
 
@@ -114,7 +117,7 @@ class Session(object):
         parser = OneXLogin()
         parser.parse(response)
 
-        self.session_id = response.cookies.get('RETS-Session-ID', '')
+        self.session_id = response.cookies.get(self.cookie_name, '')
 
         if parser.headers.get('RETS-Version') is not None:
             self.version = str(parser.headers.get('RETS-Version'))

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -15,9 +15,9 @@ class SessionTester(unittest.TestCase):
 
         with responses.RequestsMock() as resps:
             resps.add(resps.POST, 'http://server.rets.com/rets/Login.ashx',
-                      body=contents, status=200)
+                      body=contents, status=200, headers={'Set-Cookie': 'ASP.NET_SessionId=zacqcc1gjhkmazjznjmyrinq;'})
             self.session = Session(login_url='http://server.rets.com/rets/Login.ashx', username='retsuser',
-                                   version='RETS/1.7.2')
+                                   version='RETS/1.7.2', cookie_name='ASP.NET_SessionId')
             self.session.login()
 
     def test_system_metadata(self):
@@ -246,6 +246,9 @@ class SessionTester(unittest.TestCase):
     def test_agent_digest_hash(self):
         self.session.user_agent_password = "testing"
         self.assertIsNotNone(self.session._user_agent_digest_hash())
+
+    def test_session_cookie_name(self):
+        self.assertEqual(self.session.session_id, 'zacqcc1gjhkmazjznjmyrinq')
 
     def test_change_parser_automatically(self):
         self.assertEqual(self.session.metadata_format, 'COMPACT-DECODED')


### PR DESCRIPTION
## Description
See issue. 

## GitHub Issues
https://github.com/refindlyllc/rets/issues/185
