### PR TITLE
Port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # RETS Changelog
 
+## 0.4.5
+* If a non-standard port is used during the login, that port is used for all capability requests if the capability URI is supplied and not a URL.
+
 ## 0.4.4
 * Allowing custom session id cookie name viw the session_id_cookie_name parameter in the Session object
 

--- a/rets/__init__.py
+++ b/rets/__init__.py
@@ -2,7 +2,7 @@ from .session import Session
 from .exceptions import RETSException
 
 __title__ = 'rets'
-__version__ = '0.4.4'
+__version__ = '0.4.5'
 __author__ = 'REfindly'
 __license__ = 'MIT'
 __copyright__ = 'Copyright 2017 REfindly'

--- a/rets/session.py
+++ b/rets/session.py
@@ -104,7 +104,8 @@ class Session(object):
                 raise ValueError("Cannot automatically determine absolute path for {0!s} given.".format(uri))
 
             parts = urlparse(login_url)
-            uri = parts.scheme + '://' + parts.hostname + '/' + uri.lstrip('/')
+            port = ':{}'.format(parts.port) if parts.port else ''
+            uri = parts.scheme + '://' + parts.hostname + port + '/' + uri.lstrip('/')
 
         self.capabilities[name] = uri
 

--- a/tests/rets_responses/Login_relative_url.xml
+++ b/tests/rets_responses/Login_relative_url.xml
@@ -1,0 +1,17 @@
+<RETS ReplyCode="0" ReplyText="Operation Success.">
+<RETS-RESPONSE>
+MemberName=
+User=Username,NULL,NULL,Username
+Broker=
+MetadataVersion=1.11.75995
+MetadataTimestamp=2016-11-17T17:24:24Z
+MinMetadataTimestamp=2016-11-17T17:24:24Z
+Login=/rets/Login.ashx
+Logout=/rets/Logout.ashx
+Search=/rets/Search.ashx
+GetMetadata=/rets/GetMetadata.ashx
+GetObject=/rets/GetObject.ashx
+Update=/rets/Update.ashx
+PostObject=/rets/PostObject.ashx
+</RETS-RESPONSE>
+</RETS>

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,6 +1,7 @@
 import unittest
 
 import responses
+from six.moves.urllib.parse import urlparse
 
 from rets.exceptions import RETSException
 from rets.session import Session
@@ -419,3 +420,18 @@ class LoginTester(unittest.TestCase):
                          version='1.5')
             s2.login()
             self.assertIn(u'Action', list(s2.capabilities.keys()))
+
+    def test_port_added_to_actions(self):
+        with open('tests/rets_responses/Login_relative_url.xml') as f:
+            contents = ''.join(f.readlines())
+
+        with responses.RequestsMock() as resps:
+            resps.add(resps.POST, 'http://server.rets.com:9999/rets/Login.ashx',
+                      body=contents, status=200)
+            s = Session(login_url='http://server.rets.com:9999/rets/Login.ashx', username='retsuser', version='1.5')
+            s.login()
+
+            for cap in s.capabilities.values():
+                parts = urlparse(cap)
+                self.assertEqual(parts.port, 9999)
+


### PR DESCRIPTION
## Description
If the login response provides relative paths to the capabilities and a non-standard port was used during the login request, reuse that non-standard port on all requests to the capabilities. 

## GitHub Issues
<!-- Proposed changes should be discussed in an issue before submitting a PR. -->
<!-- Link to relevant tickets here. -->
Closes #190 