### PR TITLE
Check lookup key if lookuptype key is not present

### DIFF
--- a/rets/parsers/metadata.py
+++ b/rets/parsers/metadata.py
@@ -105,6 +105,10 @@ class StandardXMLetadata(Base):
         for k in base.keys():
             if k.lower() == key:
                 key_cap = k
+            # Some servers don't index lookup correctly for the given RETS version; let's address that here
+            elif key == 'lookuptype':
+                if k.lower() == 'lookup':
+                    key_cap = k
 
         if not key_cap:
             msg = 'Could not find {0!s} in the response XML'.format(key)

--- a/tests/rets_responses/STANDARD-XML/GetMetadata_lookup2.xml
+++ b/tests/rets_responses/STANDARD-XML/GetMetadata_lookup2.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<RETS ReplyCode="0" ReplyText="Operation Successful">
+<METADATA>
+<METADATA-LOOKUP_TYPE Resource="Property" Lookup="mls_cooling" Version="1.01.00010" Date="Tue, 22 Aug 2017 00:00:00 GMT">
+<Lookup>
+<LongValue>Central</LongValue>
+<ShortValue>1</ShortValue>
+<Value>1</Value>
+</Lookup>
+<Lookup>
+<LongValue>None</LongValue>
+<ShortValue>3</ShortValue>
+<Value>3</Value>
+</Lookup>
+<Lookup>
+<LongValue>Window unit(s)</LongValue>
+<ShortValue>4</ShortValue>
+<Value>4</Value>
+</Lookup>
+<Lookup>
+<LongValue>Other</LongValue>
+<ShortValue>5</ShortValue>
+<Value>5</Value>
+</Lookup>
+</METADATA-LOOKUP_TYPE>
+</METADATA>
+</RETS>

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -354,6 +354,17 @@ class Session15Tester(unittest.TestCase):
 
         self.assertEqual(len(lookup_values), 9)
 
+    def test_alternative_lookup_type_metadata(self):
+        with open('tests/rets_responses/STANDARD-XML/GetMetadata_lookup2.xml') as f:
+            contents = ''.join(f.readlines())
+
+        with responses.RequestsMock() as resps:
+            resps.add(resps.POST, 'http://server.rets.com/rets/GetMetadata.ashx',
+                      body=contents, status=200)
+            lookup_values = self.session.get_lookup_values(resource='Property', lookup_name='mls_cooling')
+
+        self.assertEqual(len(lookup_values), 4)
+
     def test_object_metadata(self):
         with open('tests/rets_responses/STANDARD-XML/GetMetadata_objects.xml') as f:
             contents = ''.join(f.readlines())


### PR DESCRIPTION
## Description
Some feeds seem to return `Lookup` instead of `LookupType` when requesting lookup value metadata. This is a case that [phRETS already handles](https://github.com/troydavisson/PHRETS/blob/master/src/Parsers/GetMetadata/LookupType.php#L19), and I've more or less copied the solution here.

I've tested this against several feeds: one that returns the expected `LookupType` key, and one that doesn't.
