### PR TITLE
Request timeout

### DIFF
--- a/rets/session.py
+++ b/rets/session.py
@@ -45,6 +45,7 @@ class Session(object):
         metadata_format="COMPACT-DECODED",
         session_id_cookie_name="RETS-Session-ID",
         search_parser=None,
+        timeout=15,
     ):
         """
         Session constructor
@@ -71,6 +72,7 @@ class Session(object):
         self.cache_metadata = cache_metadata
         self.session_id_cookie_name = session_id_cookie_name
         self.search_parser = search_parser
+        self.timeout = timeout
         self.capabilities = {}
         self.version = (
             version
@@ -466,7 +468,7 @@ class Session(object):
         ):  # Action Requests should always be GET
             query = options.get("query")
             response = self.client.post(
-                url, data=query, headers=options["headers"], stream=stream
+                url, data=query, headers=options["headers"], stream=stream, timeout=self.timeout
             )
         else:
             if "query" in options:
@@ -475,7 +477,7 @@ class Session(object):
                     for k, v in options["query"].items()
                 )
 
-            response = self.client.get(url, headers=options["headers"], stream=stream)
+            response = self.client.get(url, headers=options["headers"], stream=stream, timeout=self.timeout)
 
         if response.status_code in [400, 401]:
             if capability == "Login":


### PR DESCRIPTION
## Description
Session Class does not currently utilize the timeout variable resulting in requests occasionally hanging indefinitely


from:
https://2.python-requests.org/en/master/user/quickstart/#timeouts

> Nearly all production code should use this parameter in nearly all requests. Failure to do so can cause your program to hang indefinitely


https://github.com/refindlyllc/rets/issues/217