### PR TITLE
using a generator, major release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
 - '3.5'
 - '3.6'
 - '3.7'
+- '3.8'
 cache: pip
 install:
 - pip install setuptools --upgrade; pip install -r test_requirements.txt; python setup.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # RETS Changelog
 
+## 1.0.0
+* Major release. Search results return generator instead of list for lower-footprint processing. Possibly a breaking change depending upon usage.
+* Support Python 3.8
+
 ## 0.4.11
 
 * Falls back to basic auth if digest returns 401 response on login

--- a/README.md
+++ b/README.md
@@ -346,7 +346,7 @@ At least four bedrooms, two to three bathrooms, under $150,000.
 
 ### Search Results
 
-Searches with the RETS client return a list of dictionaries that represents listings of a search result.
+Searches with the RETS client return a generator of dictionaries that represents listings of a search result.
 
 ### Custom Results Parser
 

--- a/rets/__init__.py
+++ b/rets/__init__.py
@@ -2,7 +2,7 @@ from .session import Session
 from .exceptions import RETSException
 
 __title__ = "rets"
-__version__ = "0.4.11"
+__version__ = "0.1.0"
 __author__ = "REfindly"
 __license__ = "MIT"
 __copyright__ = "Copyright 2019 REfindly"

--- a/rets/parsers/search.py
+++ b/rets/parsers/search.py
@@ -27,7 +27,6 @@ class OneXSearchCursor(Base):
         response.raw.decode_content = True
         events = ET.iterparse(BytesIO(response.content))
 
-        results = []
         for event, elem in events:
             # Analyze search record data
             if "DATA" == elem.tag:
@@ -37,7 +36,7 @@ class OneXSearchCursor(Base):
                     if column != ""
                 }
                 self.parsed_rows += 1  # Rows parsed with all requests
-                results.append(data_dict)
+                yield data_dict
 
             # Handle reply code
             elif "RETS" == elem.tag:
@@ -67,12 +66,10 @@ class OneXSearchCursor(Base):
                 logger.debug(
                     "Received {0!s} results from this search".format(self.parsed_rows)
                 )
-                raise MaxrowException(results)
+                raise MaxrowException(self.parsed_rows)
 
             else:
                 # This is a tag we don't process (like COUNT)
                 continue
 
             elem.clear()
-
-        return results

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -247,12 +247,12 @@ class SessionTester(unittest.TestCase):
                 status=200,
                 stream=True,
             )
-            results = self.session.search(
+            results_gen = self.session.search(
                 resource="Property",
                 resource_class="RES",
                 search_filter={"ListingPrice": 200000},
             )
-
+            results = list(results_gen)
             self.assertEqual(len(results), 3)
 
             resps.add(
@@ -263,13 +263,14 @@ class SessionTester(unittest.TestCase):
                 stream=True,
             )
 
-            results1 = self.session.search(
+            results1_gen = self.session.search(
                 resource="Property",
                 resource_class="RES",
                 limit=3,
                 dmql_query="ListingPrice=200000",
                 optional_parameters={"RestrictedIndicator": "!!!!"},
             )
+            results1 = list(results1_gen)
             self.assertEqual(len(results1), 3)
 
             resps.add(
@@ -281,13 +282,14 @@ class SessionTester(unittest.TestCase):
             )
 
             self.session.search_parser = CreaStandardXParser()
-            results2 = self.session.search(
+            results2_gen = self.session.search(
                 resource="Property",
                 resource_class="Property",
                 limit=1,
                 response_format="STANDARD-XML",
                 dmql_query="(ID=20270724)",
             )
+            results2 = list(results2_gen)
             self.assertEqual(len(results2), 1)
             self.session.search_parser = None
 
@@ -305,7 +307,7 @@ class SessionTester(unittest.TestCase):
                     dmql_query="ListingPrice=200000",
                     optional_parameters={"Format": "Somecrazyformat"},
                 )
-                print(r)
+                print(list(r))
 
     def test_auto_offset(self):
         with open("tests/rets_responses/COMPACT-DECODED/Search_1of2.xml") as f:
@@ -329,12 +331,12 @@ class SessionTester(unittest.TestCase):
                 status=200,
                 stream=True,
             )
-            results = self.session.search(
+            results_gen = self.session.search(
                 resource="Property",
                 resource_class="RES",
                 search_filter={"ListingPrice": 200000},
             )
-
+            results = list(results_gen)
             self.assertEqual(len(results), 6)
 
     def test_cache_metadata(self):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py34, py35, py36, py37
+envlist = py27, py34, py35, py36, py37, py38
 [testenv]
 deps =
     -r requirements.txt


### PR DESCRIPTION
## Description
Possibly Breaking Change, the `search` method now returns a generator instead of a list. This allows requests that require multiple requests to the RETS server to stream their results as they are received. 

